### PR TITLE
Implement the count of captured stones

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ After running the command, you should see a window pop up with a Go board. You c
 ### TODO
 
 - [ ] Implement the time control system
-- [ ] Implement the count of captured stones
+- [x] Implement the count of captured stones
 - [ ] Implement the end-game detection
 - [x] Implement the simple scoring system
 - [ ] Implement the complex scoring system

--- a/tests/test_board.py
+++ b/tests/test_board.py
@@ -296,7 +296,11 @@ class TestBoard(unittest.TestCase):
                 2,
                 1,
             ),
-            (".W.../WBW../.WWW./.WBBW/WBWWB", 2, 5),
+            (
+                ".W.../WBW../.WWW./.WBBW/WBWWB",
+                2,
+                5,
+            ),
         ]
     )
     def test_initialization_counts_captured_stones_correctly(
@@ -312,6 +316,18 @@ class TestBoard(unittest.TestCase):
         board = Board(state)
         self.assertEqual(board.white_captured, expected_white_captured)
         self.assertEqual(board.black_captured, expected_black_captured)
+
+    def test_white_captured(self):
+        board = Board("W..../B.W../..B../.B.../.....")
+        self.assertEqual(board.white_captured, 0)
+        board.place_figure(Move(Position(1, 0), Stone.BLACK))
+        self.assertEqual(board.white_captured, 1)
+
+    def test_black_captured(self):
+        board = Board("B..../W.B../..W../.B.../.....")
+        self.assertEqual(board.white_captured, 0)
+        board.place_figure(Move(Position(1, 0), Stone.WHITE))
+        self.assertEqual(board.black_captured, 1)
 
 
 if __name__ == "__main__":

--- a/tests/test_board.py
+++ b/tests/test_board.py
@@ -284,6 +284,35 @@ class TestBoard(unittest.TestCase):
         board = Board(state)
         self.assertEqual(board.state_as_string, expected_state)
 
+    @parameterized.expand(
+        [
+            (
+                "...../...../...../...../.....",
+                0,
+                0,
+            ),
+            (
+                ".W.../WBW../.W.../..BB./.BWWB",
+                2,
+                1,
+            ),
+            (".W.../WBW../.WWW./.WBBW/WBWWB", 2, 5),
+        ]
+    )
+    def test_initialization_counts_captured_stones_correctly(
+        self,
+        state: list[list[int]] | str,
+        expected_white_captured: int,
+        expected_black_captured: int,
+    ):
+        """
+        If the territories are not seized during the initialization,
+        they must be systematically seized
+        """
+        board = Board(state)
+        self.assertEqual(board.white_captured, expected_white_captured)
+        self.assertEqual(board.black_captured, expected_black_captured)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/weiqi/board.py
+++ b/weiqi/board.py
@@ -1,5 +1,4 @@
 from itertools import product
-from pickle import PROTO
 
 from weiqi.group import Group
 from weiqi.position import Position

--- a/weiqi/board.py
+++ b/weiqi/board.py
@@ -1,4 +1,5 @@
 from itertools import product
+from pickle import PROTO
 
 from weiqi.group import Group
 from weiqi.position import Position
@@ -84,12 +85,12 @@ class Board:
     def position_in_bounds(self, position: Position) -> bool:
         return 0 <= position.x < self._size and 0 <= position.y < self._size
 
-    def _find_groups_without_liberties(self) -> list[Group]:
-        return [
+    def _find_groups_without_liberties(self) -> set[Group]:
+        return {
             self._group_at_position(position)
             for position in self._get_not_empty_positions()
             if not self._group_at_position(position).liberties
-        ]
+        }
 
     def _get_not_empty_positions(self) -> list[Position]:
         return [

--- a/weiqi/group.py
+++ b/weiqi/group.py
@@ -9,3 +9,17 @@ class Group:
         self.positions = positions
         self.liberties = liberties
         self.figure = figure
+
+    def __hash__(self):
+        return hash(
+            (frozenset(self.positions), frozenset(self.liberties), self.figure)
+        )
+
+    def __eq__(self, other):
+        if not isinstance(other, Group):
+            return False
+        return (
+            frozenset(self.positions) == frozenset(other.positions)
+            and frozenset(self.liberties) == frozenset(other.liberties)
+            and self.figure == other.figure
+        )


### PR DESCRIPTION
This pull request includes updates to the `weiqi` board game implementation to track captured stones and updates the `README.md` to reflect the completed feature.

### Updates to `weiqi` board game implementation:

* Added attributes to track the number of captured white and black stones in the `Board` class constructor (`weiqi/board.py`). [[1]](diffhunk://#diff-0abf6f56064445e41d363d7be385046aaf173b82683a8f35c07285d6a19efd60R15-R16) [[2]](diffhunk://#diff-0abf6f56064445e41d363d7be385046aaf173b82683a8f35c07285d6a19efd60R26-R27)
* Introduced properties to access the number of captured white and black stones (`weiqi/board.py`).
* Updated the `__remove_group` method to increment the count of captured stones when a group is removed (`weiqi/board.py`).
* Modified the `place_figure` method to handle the state of captured stones correctly, ensuring the state is reverted if an invalid move is detected (`weiqi/board.py`). [[1]](diffhunk://#diff-0abf6f56064445e41d363d7be385046aaf173b82683a8f35c07285d6a19efd60R303-R305) [[2]](diffhunk://#diff-0abf6f56064445e41d363d7be385046aaf173b82683a8f35c07285d6a19efd60L294-R330)

### Documentation updates:

* Marked the task for implementing the count of captured stones as completed in the `README.md` file.