### PR TITLE
Fix state as string

### DIFF
--- a/tests/test_board.py
+++ b/tests/test_board.py
@@ -260,6 +260,30 @@ class TestBoard(unittest.TestCase):
         board = Board(state)
         self.assertEqual(board.score, expected_score)
 
+    @parameterized.expand(
+        [
+            (
+                "...../..W../...../...../.....",
+                "...../..W../...../...../.....",
+            ),
+            (
+                ".W.../WBW../.W.../..BB./.BWWB",
+                ".W.../W.W../.W.../..BB./.B..B",
+            ),
+            (
+                "...../...../...../...../.....",
+                "...../...../...../...../.....",
+            ),
+            (
+                ".W.../...../...../...../.....",
+                ".W.../...../...../...../.....",
+            ),
+        ]
+    )
+    def test_string_state(self, state: str, expected_state: str):
+        board = Board(state)
+        self.assertEqual(board.state_as_string, expected_state)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/weiqi/board.py
+++ b/weiqi/board.py
@@ -241,9 +241,9 @@ class Board:
         return "/".join(
             "".join(
                 symbols.get(self._figures.get(Position(x, y)), ".")
-                for y in range(self.size)
+                for x in range(self.size)
             )
-            for x in range(self.size)
+            for y in range(self.size)
         )
 
     @staticmethod


### PR DESCRIPTION
This pull request introduces a new test case and fixes a bug in the `state_as_string` method. The most important changes include the addition of the `test_string_state` method and the correction of the iteration order in the `state_as_string` method.

### New Test Case:

* [`tests/test_board.py`](diffhunk://#diff-1d43b46a7307c9f629a352b184043f92c5f26dc925cc310ed2d5c9ab9507967fR263-R286): Added the `test_string_state` method to validate the string representation of the board state using parameterized inputs.

### Bug Fix:

* [`weiqi/board.py`](diffhunk://#diff-0abf6f56064445e41d363d7be385046aaf173b82683a8f35c07285d6a19efd60L244-R247): Corrected the iteration order in the `state_as_string` method to properly generate the board's string representation.