### PR TITLE
Fixed errors

### DIFF
--- a/weiqi/board.py
+++ b/weiqi/board.py
@@ -296,6 +296,8 @@ class Board:
         )
 
     def place_figure(self, move: Move) -> None:
+        if move.position is None:
+            raise ValueError("Position is required.")
         if not self.position_in_bounds(move.position):
             raise ValueError("Position out of bounds.")
         if self._figures.get(move.position) is not None:

--- a/weiqi/move.py
+++ b/weiqi/move.py
@@ -8,8 +8,8 @@ from weiqi.figure import Stone
 
 @dataclass(frozen=True)
 class Move:
-    position: Position
-    figure: Stone | None
+    position: Position | None
+    figure: Stone
     timestamp: datetime.datetime = field(init=False)
 
     def __post_init__(self):

--- a/weiqi/player.py
+++ b/weiqi/player.py
@@ -23,7 +23,9 @@ class Player(Generic[TUser]):
     def figure(self) -> Stone:
         return self._figure
 
-    def make_move(self, game: "WeiqiGame[TUser]", position: Position) -> None:
+    def make_move(
+        self, game: "WeiqiGame[TUser]", position: Position | None
+    ) -> None:
         move = Move(position=position, figure=self.figure)
         game.make_move(self, move)
 


### PR DESCRIPTION
This pull request includes changes to the `weiqi` module to handle cases where a move's position can be `None`. The changes ensure that the code properly raises errors and handles optional positions in moves.

Changes to handle optional move positions:

* [`weiqi/board.py`](diffhunk://#diff-0abf6f56064445e41d363d7be385046aaf173b82683a8f35c07285d6a19efd60R299-R300): Added a check to raise a `ValueError` if the move's position is `None` in the `place_figure` method.
* [`weiqi/move.py`](diffhunk://#diff-ed4bb36dfaea75b6a59e62359422bd654d9675ca560c8d29a5b6debb441b0f6bL11-R12): Modified the `Move` dataclass to allow `position` to be `None` and made `figure` non-optional.
* [`weiqi/player.py`](diffhunk://#diff-be3a7a18c719d0624c21872e6e0ba11ee84acf3aec54d3b261e8628413a391b8L26-R28): Updated the `make_move` method to accept a `Position | None` type for the position parameter.