### PR TITLE
Update RandomBot.

### DIFF
--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -16,7 +16,7 @@ class MyTestCase(unittest.TestCase):
         ]
     )
     def test_calc_field_boars(self, matrix: list[list[int]], expected: float):
-        self.assertEqual(RandomBot._calc_field_boars(matrix), expected)
+        self.assertEqual(RandomBot._calc_field_board(matrix), expected)
 
 
 if __name__ == "__main__":

--- a/weiqi/players/bot.py
+++ b/weiqi/players/bot.py
@@ -31,7 +31,7 @@ class BaseBot(ABC):
 
 class RandomBot(BaseBot):
     @staticmethod
-    def _calc_field_boars(matrix: list[list[int]]) -> float:
+    def _calc_field_board(matrix: list[list[int]]) -> float:
         """Calculates the field board in percentage from the matrix."""
         count_non_zero = sum(1 for row in matrix for x in row if x != 0)
         total_elements = len(matrix) * len(matrix[0]) if matrix else 0
@@ -65,8 +65,8 @@ class RandomBot(BaseBot):
 
     def _should_pass_on_high_occupancy(self, board: Board) -> bool:
         state_as_matrix = board.state_as_matrix
-        fielded_board = self._calc_field_boars(state_as_matrix)
-        return 0.7 <= fielded_board <= 0.8 and random.random() < 0.4
+        fielded_board = self._calc_field_board(state_as_matrix)
+        return 0.8 <= fielded_board <= 1.0 and random.random() < 0.4
 
     def _make_pass_move(self, game: "WeiqiGame[TUser]") -> Move:
         """Makes a pass move."""


### PR DESCRIPTION
This pull request includes a couple of changes to the `weiqi/players/bot.py` file, focusing on fixing a typo in a method name and adjusting the logic for determining when the bot should pass.

Fixes and logic adjustments:

* Corrected a typo in the method name from `_calc_field_boars` to `_calc_field_board` in the `RandomBot` class.
* Updated the logic in the `make_move` method to adjust the fielded board percentage range for passing from `0.7 <= fielded_board <= 0.8` to `0.8 <= fielded_board <= 1.0`.